### PR TITLE
Fix NetworkManager skipping the first access point

### DIFF
--- a/access_points/__init__.py
+++ b/access_points/__init__.py
@@ -183,7 +183,7 @@ class NetworkManagerWifiScanner(WifiScanner):
 
         results = []
 
-        for line in output.strip().split('\n')[1:]:
+        for line in output.strip().split('\n'):
             ssid, bssid, quality, security = split_escaped(line, ':')
             access_point = AccessPoint(ssid, bssid, int(quality), security)
             results.append(access_point)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -36,6 +36,7 @@ def parse_output(wifi_scanner, fname):
     output = read_output(fname)
     aps = wifi_scanner.parse_output(output)
     assert_access_point(aps)
+    return aps
 
 
 def test_scan():
@@ -45,16 +46,20 @@ def test_scan():
 
 
 def test_iwlist():
-    parse_output(IwlistWifiScanner(), "iwlist_test.txt")
+    aps = parse_output(IwlistWifiScanner(), "iwlist_test.txt")
+    assert len(aps) == 9
 
 
 def test_nmcli():
-    parse_output(NetworkManagerWifiScanner(), "nmcli_test.txt")
+    aps = parse_output(NetworkManagerWifiScanner(), "nmcli_test.txt")
+    assert len(aps) == 9
 
 
 def test_windows():
-    parse_output(WindowsWifiScanner(), "windows_test.txt")
+    aps = parse_output(WindowsWifiScanner(), "windows_test.txt")
+    assert len(aps) == 37
 
 
 def test_osx():
-    parse_output(OSXWifiScanner(), "osx_test.txt")
+    aps = parse_output(OSXWifiScanner(), "osx_test.txt")
+    assert len(aps) == 5


### PR DESCRIPTION
Unfortunately, this slipped under the radar when I changed to the machine readable output of NetworkManager.