### PR TITLE
Fix for ensure_str which fails when there are weird characters in an SSID

### DIFF
--- a/access_points/__init__.py
+++ b/access_points/__init__.py
@@ -11,9 +11,9 @@ import json
 
 def ensure_str(output):
     try:
-        output = output.decode("utf8")
+        output = output.decode("utf8",errors='ignore')
     except UnicodeDecodeError:
-        output = output.decode("utf16")
+        output = output.decode("utf16",errors='ignore')
     except AttributeError:
         pass
     return output


### PR DESCRIPTION
On Windows 10, Python 2.7 64-bit, get_access_points() sometimes fails with this traceback:

    Traceback (most recent call last):
      File "C:\test\geolocate.py", line 6, in <module>
        accessPoints = wifi_scanner.get_access_points()
      File "C:\Python27\lib\site-packages\access_points\__init__.py", line 82, in get_access_points
        results = self.parse_output(ensure_str(out))
      File "C:\Python27\lib\site-packages\access_points\__init__.py", line 17, in ensure_str
        output = output.decode("utf16")
      File "C:\Python27\lib\encodings\utf_16.py", line 16, in decode
        return codecs.utf_16_decode(input, errors, True)
    UnicodeDecodeError: 'utf16' codec can't decode byte 0x0a in position 9392: truncated data

This happened when someone in the vicinity had this as their SSID: 

    Harvey�?Ts iPhone 

In hex, this is: 486172766579833f5473206950686f6e65. The strange character is 79833f54. The problem seems to be related to [this](https://dhenrie0208.wordpress.com/projects/bad-iphone-ssids-explained/) which says that this is all Microsoft's fault. 

In any case, this change is tested on Windows 10 with Python 2.7, 3.5, & 3.6. 