### PR TITLE
macOS Monterey elides BSSID without sudo

### DIFF
--- a/access_points/__init__.py
+++ b/access_points/__init__.py
@@ -94,22 +94,28 @@ class OSXWifiScanner(WifiScanner):
         cmd = "airport -s"
         return path + cmd
 
+    # OSX Monterey doesn't output the BSSID unless you `sudo` which means the
+    # old method using a regexp to match those lines fails.  Since the output
+    # is column-formatted, we can use that instead and it works on both
+    # Monterey-without-BSSID and pre-Monterey-with-BSSID.
     def parse_output(self, output):
         results = []
-        # 5 times 2 "letters and/or digits" followed by ":"
-        # Then one time only 2 "letters and/or digits"
-        # Use non-capturing groups (?:...) to use {} for amount
-        # One wrapping group (...) to capture the whole thing
-        bbsid_re = re.compile("((?:[0-9a-zA-Z]{2}:){5}(?:[0-9a-zA-Z]){2})")
         security_start_index = False
+        # First line looks like this (multiple whitespace truncated to fit.)
+        # `\w+SSID BSSID\w+  RSSI CHANNEL HT CC SECURITY (auth/unicast/group)`
+        # `       ^ ssid_end_index`
+        # `                  ^ rssi_start_index`
+        # `        ^       ^ bssid`
         for line in output.split("\n"):
             if line.strip().startswith("SSID BSSID"):
                 security_start_index = line.index("SECURITY")
+                ssid_end_index = line.index("SSID") + 4
+                rssi_start_index = line.index("RSSI")
             elif line and security_start_index and 'IBSS' not in line:
                 try:
-                    ssid = bbsid_re.split(line)[0].strip()
-                    bssid = bbsid_re.findall(line)[0]
-                    rssi = bbsid_re.split(line)[-1].strip().split()[0]
+                    ssid = line[0:ssid_end_index].strip()
+                    bssid = line[ssid_end_index+1:rssi_start_index-1].strip()
+                    rssi = line[rssi_start_index:rssi_start_index+4].strip()
                     security = line[security_start_index:]
                     ap = AccessPoint(ssid, bssid, rssi_to_quality(int(rssi)), security)
                     results.append(ap)

--- a/data/osx_monterey_test.txt
+++ b/data/osx_monterey_test.txt
@@ -1,0 +1,6 @@
+                            SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
+                     X000X000X00                   -83  6       Y  -- WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)
+               XXX-XXX0000000000                   -68  5       Y  -- WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)
+                       XXXXXXXXX                   -52  8       N  -- WPA(PSK/TKIP/TKIP)
+                          XX-XXX                   -75  10      Y  -- WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)
+                   XXXXXXX00X0X0                   -58  10      N  -- WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -26,18 +26,20 @@ def read_output(fn):
         return f.read()
 
 
-def assert_access_point(aps):
+def assert_access_point(aps, bssid_required=True):
     assert isinstance(aps, list)
     for ap in aps:
         assert isinstance(ap['quality'], int)
         assert isinstance(ap['ssid'], basestring) and ap['ssid'] != ''
-        assert isinstance(ap['bssid'], basestring) and ap['bssid'] != ''
+        # `ap['bssid']` can sometimes be empty, e.g. on macOS Monterey
+        if bssid_required:
+            assert isinstance(ap['bssid'], basestring) and ap['bssid'] != ''
 
 
-def parse_output(wifi_scanner, fname):
+def parse_output(wifi_scanner, fname, bssid_required=True):
     output = read_output(fname)
     aps = wifi_scanner.parse_output(output)
-    assert_access_point(aps)
+    assert_access_point(aps, bssid_required)
     return aps
 
 
@@ -53,7 +55,9 @@ def assert_all_included(aps, answers):
 def test_scan():
     scanner = get_scanner()
     aps = scanner.get_access_points()
-    assert_access_point(aps)
+    # We don't know if we necessarily get BSSIDs from a live scan;
+    # best to err on the side of caution here and not require a match.
+    assert_access_point(aps, False)
 
 
 def test_iwlist():
@@ -248,6 +252,35 @@ def test_osx():
          'WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)')
     ]
     assert_all_included(aps, osx_ans)
+
+def test_osx_monterey():
+    # BSSID isn't a required match for macOS Monterey because it's not there.
+    aps = parse_output(OSXWifiScanner(), "osx_monterey_test.txt", False)
+    assert len(aps) == 5
+
+    osx_monterey_ans = [
+        ('X000X000X00',
+         '',
+         rssi_to_quality(-83),
+         'WPA(PSK/AES,TKIP/TKIP) WPA2(PSK/AES,TKIP/TKIP)'),
+        ('XXX-XXX0000000000',
+         '',
+         rssi_to_quality(-68),
+         'WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)'),
+        ('XXXXXXXXX',
+         '',
+         rssi_to_quality(-52),
+         'WPA(PSK/TKIP/TKIP)'),
+        ('XX-XXX',
+         '',
+         rssi_to_quality(-75),
+         'WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)'),
+        ('XXXXXXX00X0X0',
+         '',
+         rssi_to_quality(-58),
+         'WPA(PSK/TKIP/TKIP) WPA2(PSK/AES/TKIP)')
+    ]
+    assert_all_included(aps, osx_monterey_ans)
 
 
 def test_termux():


### PR DESCRIPTION
Fixes #21 by parsing lines using column slicing rather than matching a BSSID regexp (which obviously fails because Monterey `airport` won't give you the BSSID unless you're root and we probably don't want to be running this as root.)

Tested on Monterey-without-BSSID, Monterey-with-BSSID, and pre-Monterey-with-BSSID outputs.  New test for Monterey-style output added to the test suite and data.

(Minor caveat: Only tested with `tox` using `py27` and `py39` because my Pythons are currently a confused mess due to running on Apple Silicon.)