### PR TITLE
adjust line indices when encounter CJK characters

### DIFF
--- a/access_points/__init__.py
+++ b/access_points/__init__.py
@@ -8,18 +8,11 @@ import platform
 import subprocess
 import json
 
-def cjk_detect(texts):
-    for c in texts:
-        # korean
-        if re.search("[\uac00-\ud7a3]", texts):
-            return "ko"
-        # japanese
-        if re.search("[\u3040-\u30ff]", texts):
-            return "ja"
-        # chinese
-        if re.search("[\u4e00-\u9FFF]", texts):
-            return "zh"
-        return None
+def count_cjk_characters(string):
+    # Use the regex to find all CJK characters in the string
+    cjk_characters = re.findall(r'[\u4e00-\u9fff]', string)
+    # Return the number of characters found
+    return len(cjk_characters)
 
 def ensure_str(output):
     try:
@@ -125,8 +118,10 @@ class OSXWifiScanner(WifiScanner):
             elif line and security_start_index and 'IBSS' not in line:
                 try:
                     ssid = line[0:ssid_end_index].strip()
-                    if cjk_detect(ssid):
-                        line = line[0:ssid_end_index] + 19 * ' ' + line[ssid_end_index+1:]
+                    cjk_len = count_cjk_characters(ssid)
+                    if cjk_len > 0:
+                        line = line[0:ssid_end_index] + (cjk_len * 2 + 1) * ' ' + line[ssid_end_index+1:]
+
                     bssid = line[ssid_end_index+1:rssi_start_index-1].strip()
                     rssi = line[rssi_start_index:rssi_start_index+4].strip()
                     security = line[security_start_index:]

--- a/access_points/__init__.py
+++ b/access_points/__init__.py
@@ -9,16 +9,17 @@ import subprocess
 import json
 
 def cjk_detect(texts):
-    # korean
-    if re.search("[\uac00-\ud7a3]", texts):
-        return "ko"
-    # japanese
-    if re.search("[\u3040-\u30ff]", texts):
-        return "ja"
-    # chinese
-    if re.search("[\u4e00-\u9FFF]", texts):
-        return "zh"
-    return None
+    for c in texts:
+        # korean
+        if re.search("[\uac00-\ud7a3]", texts):
+            return "ko"
+        # japanese
+        if re.search("[\u3040-\u30ff]", texts):
+            return "ja"
+        # chinese
+        if re.search("[\u4e00-\u9FFF]", texts):
+            return "zh"
+        return None
 
 def ensure_str(output):
     try:
@@ -123,33 +124,12 @@ class OSXWifiScanner(WifiScanner):
                 rssi_start_index = line.index("RSSI")
             elif line and security_start_index and 'IBSS' not in line:
                 try:
-                    # align ssid columns to right,
-                    # so that ssid with spaces at the beginning are not truncated
-
-                    # count how many chinese characters are in the ssid
                     ssid = line[0:ssid_end_index].strip()
-                    countCJK = 0
-                    for c in ssid:
-                        if cjk_detect(c):
-                            countCJK += 1
-
-                    # add spaces to the beginning of the line
-                    line = ' ' * countCJK + line
-
-                    # adjust the indices
-                    ssid_end_index -= countCJK
-                    rssi_start_index -= countCJK
-                    security_start_index -= countCJK
-
+                    if cjk_detect(ssid):
+                        line = line[0:ssid_end_index] + 19 * ' ' + line[ssid_end_index+1:]
                     bssid = line[ssid_end_index+1:rssi_start_index-1].strip()
                     rssi = line[rssi_start_index:rssi_start_index+4].strip()
                     security = line[security_start_index:]
-
-                    # adjust the indices back to original
-                    ssid_end_index += countCJK
-                    rssi_start_index += countCJK
-                    security_start_index += countCJK
-
                     ap = AccessPoint(ssid, bssid, rssi_to_quality(int(rssi)), security)
                     results.append(ap)
                 except Exception as e:

--- a/data/osx_cjk_test.txt
+++ b/data/osx_cjk_test.txt
@@ -1,0 +1,6 @@
+                            SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
+                            P880                   -87  1       Y  -- RSN(PSK/AES/AES) 
+                           HuaB5                   -83  40      Y  -- RSN(PSK/AES/AES) 
+           小米共享WiFi_B496                   -76  4       Y  -- RSN(PSK/AES/AES) 
+        不要亂改網路名稱                   -71  6,-1    Y  -- RSN(PSK/AES/AES) 
+                           HuaB5                   -70  10      Y  -- RSN(PSK/AES/AES) 

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -298,3 +298,16 @@ def test_termux():
          '')
     ]
     assert_all_included(aps, termux_ans)
+
+def test_cjk():
+    aps = parse_output(OSXWifiScanner(), "osx_cjk_test.txt", False)
+    assert len(aps) == 5
+
+    osx_cjk_ans = [
+        ('P880', '', rssi_to_quality(-87), 'RSN(PSK/AES/AES' ),
+        ('HuaB5', '', rssi_to_quality(-83), 'RSN(PSK/AES/AES' ),
+        ('小米共享WiFi_B496', '', rssi_to_quality(-76), 'RSN(PSK/AES/AES' ),
+        ('不要亂改網路名稱', '', rssi_to_quality(-71), 'RSN(PSK/AES/AES' ),
+        ('HuaB5', '', rssi_to_quality(-70), 'RSN(PSK/AES/AES' ),
+    ]
+    assert_all_included(aps, osx_cjk_ans)


### PR DESCRIPTION
Through my experiment, I found that the problem is because there is no BSSID provided in `airport -s` that have CJK SSID.  Actually the chinese characters is properly indented to the left. 
<img width="1014" alt="Screen Shot 2022-12-26 at 9 46 58 PM" src="https://user-images.githubusercontent.com/49984479/209555430-d4b88350-da99-4c0a-a30b-71757c988547.png">
<img width="520" alt="Screen Shot 2022-12-26 at 9 48 20 PM" src="https://user-images.githubusercontent.com/49984479/209555514-ba9ee499-2934-435b-a5ae-92d4e0f207db.png">
So I add 19 whitespaces in the line to make it like others and it work fine. 
<img width="457" alt="Screen Shot 2022-12-26 at 9 53 05 PM" src="https://user-images.githubusercontent.com/49984479/209555894-3606acc9-77b5-4c93-aa42-dbd97fa46afc.png">
<img width="487" alt="Screen Shot 2022-12-26 at 9 53 34 PM" src="https://user-images.githubusercontent.com/49984479/209555933-63cb7965-3e9c-4150-9730-d6b43148813b.png">
